### PR TITLE
Apply Terraform best practices: capitalize tag key, add variable types, output public IP and DNS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,6 @@ resource "aws_instance" "ubuntu" {
   instance_type = var.instance_type
 
   tags = {
-    name = var.instance_name
+    Name = var.instance_name
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,3 +6,10 @@ output "instance_arn" {
   value = aws_instance.ubuntu.arn
 }
 
+output "instance_public_ip" {
+  value = aws_instance.ubuntu.public_ip
+}
+
+output "instance_public_dns" {
+  value = aws_instance.ubuntu.public_dns
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,17 @@
 variable "region" {
   description = "AWS region"
+  type        = string
   default     = "us-east-2"
 }
 
 variable "instance_type" {
   description = "Type of EC2 instance to provision"
+  type        = string
   default     = "t2.micro"
 }
 
 variable "instance_name" {
   description = "EC2 instance name"
+  type        = string
   default     = "Micro"
 }
-


### PR DESCRIPTION
This PR applies several Terraform best practices:
- Capitalizes the EC2 tag key to `Name` for AWS convention
- Adds `type = string` to all variables for stricter validation
- Adds outputs for the instance's public IP and public DNS

Please review and merge if approved.